### PR TITLE
Update all aws-java-sdk packages to v1.12.772

### DIFF
--- a/s3-access-grants-cache/pom.xml
+++ b/s3-access-grants-cache/pom.xml
@@ -78,12 +78,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3control</artifactId>
-            <version>1.12.609</version>
+            <version>1.12.772</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.609</version>
+            <version>1.12.772</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/s3-access-grants-plugin/pom.xml
+++ b/s3-access-grants-plugin/pom.xml
@@ -79,22 +79,22 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
-            <version>1.12.609</version>
+            <version>1.12.772</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-iam</artifactId>
-            <version>1.12.609</version>
+            <version>1.12.772</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.609</version>
+            <version>1.12.772</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3control</artifactId>
-            <version>1.12.609</version>
+            <version>1.12.772</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
*Issue #, if available:*
Addressing presence of https://nvd.nist.gov/vuln/detail/CVE-2024-21634

*Description of changes:*
Updating all aws-java-sdk versions to 1.12.772 (latest V1).

Ion-Java is present in java-sdk-core v1.12.609, which is used by all current sdk packages. Eg:
```
[INFO] --- dependency:3.7.0:tree (default-cli) @ java-sdk-v1-s3-access-grants-cache ---
[INFO] software.amazon.s3.accessgrants:java-sdk-v1-s3-access-grants-cache:jar:1.1.0
[INFO] \- com.amazonaws:aws-java-sdk-s3control:jar:1.12.609:compile
[INFO]    \- com.amazonaws:aws-java-sdk-core:jar:1.12.609:compile
[INFO]       \- software.amazon.ion:ion-java:jar:1.0.2:compile
```
But Ion-Java has since been removed from Java-sdk-core (removed in [version 1.12.638](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#112638-2024-01-16))

This PR will make several of the open dependabot PRs redundant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
